### PR TITLE
Rename repo from ansible-role-freeipa to ansible-role-freeipa-server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,22 +15,22 @@ all of which should be in this repository.
 
 If you want to report a bug or request a new feature, the most direct
 method is to [create an
-issue](https://github.com/cisagov/ansible-role-freeipa/issues) in this
-repository.  We recommend that you first search through existing
-issues (both open and closed) to check if your particular issue has
-already been reported.  If it has then you might want to add a comment
-to the existing issue.  If it hasn't then feel free to create a new
-one.
+issue](https://github.com/cisagov/ansible-role-freeipa-server/issues)
+in this repository.  We recommend that you first search through
+existing issues (both open and closed) to check if your particular
+issue has already been reported.  If it has then you might want to add
+a comment to the existing issue.  If it hasn't then feel free to
+create a new one.
 
 ## Pull requests ##
 
 If you choose to [submit a pull
-request](https://github.com/cisagov/ansible-role-freeipa/pulls), you
-will notice that our continuous integration (CI) system runs a fairly
-extensive set of linters and syntax checkers.  Your pull request may
-fail these checks, and that's OK.  If you want you can stop there and
-wait for us to make the necessary corrections to ensure your code
-passes the CI checks.
+request](https://github.com/cisagov/ansible-role-freeipa-server/pulls),
+you will notice that our continuous integration (CI) system runs a
+fairly extensive set of linters and syntax checkers.  Your pull
+request may fail these checks, and that's OK.  If you want you can
+stop there and wait for us to make the necessary corrections to ensure
+your code passes the CI checks.
 
 If you want to make the changes yourself, or if you want to become a
 regular contributor, then you will want to set up
@@ -78,9 +78,9 @@ can create and configure the Python virtual environment with these
 commands:
 
 ```console
-cd ansible-role-freeipa
-pyenv virtualenv <python_version_to_use> ansible-role-freeipa
-pyenv local ansible-role-freeipa
+cd ansible-role-freeipa-server
+pyenv virtualenv <python_version_to_use> ansible-role-freeipa-server
+pyenv local ansible-role-freeipa-server
 pip install -r requirements-dev.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# ansible-role-freeipa #
+# ansible-role-freeipa-server #
 
-[![Build Status](https://travis-ci.com/cisagov/ansible-role-freeipa.svg?branch=develop)](https://travis-ci.com/cisagov/ansible-role-freeipa)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-freeipa.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-freeipa/alerts/)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-freeipa.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-freeipa/context:python)
+[![Build Status](https://travis-ci.com/cisagov/ansible-role-freeipa-server.svg?branch=develop)](https://travis-ci.com/cisagov/ansible-role-freeipa-server)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-freeipa-server.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-freeipa-server/alerts/)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-freeipa-server.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-freeipa-server/context:python)
 
 This is an Ansible role for installing
-[FreeIPA](https://www.freeipa.org).
+[FreeIPA](https://www.freeipa.org) server.
 
 ## Requirements ##
 
@@ -24,11 +24,11 @@ None.
 Here's how to use it in a playbook:
 
 ```yaml
-- hosts: freeipa
+- hosts: freeipa_servers
   become: yes
   become_method: sudo
   roles:
-    - freeipa
+    - freeipa_server
 ```
 
 ## Contributing ##

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Shane Frasier
-  description: Ansible role for installing FreeIPA
+  description: Ansible role for installing FreeIPA server
   company: CISA NCATS
   license: CC0
   min_ansible_version: 2.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   platforms:
     - name: Fedora
       versions:
-        - 30
+        - 29
   galaxy_tags:
     - freeipa
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: ansible-role-freeipa
+    - role: ansible-role-freeipa-server

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,0 @@
----
-- src: https://github.com/cisagov/ansible-role-pip
-  name: pip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install FreeIPA
+- name: Install FreeIPA server
   package:
     name: freeipa-server
     state: present


### PR DESCRIPTION
A separate `ansible-role-freeipa-client` repo will also be necessary.