### PR TITLE
Remove installation of unnecessary package

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["freeipa-server", "freeipa-server-dns"])
+@pytest.mark.parametrize("pkg", ["freeipa-server"])
 def test_packages(host, pkg):
     """Test that the appropriate packages were installed."""
     assert host.package(pkg).is_installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,5 +3,4 @@
   package:
     name:
       - freeipa-server
-      - freeipa-server-dns
     state: present


### PR DESCRIPTION
We are using AWS Route53 for DNS, not FreeIPA's built-in DNS.

This pull request resolves issue #3.