### PR TITLE
Add cron job to disable inactive users

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v2.3.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,13 +23,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.17.0
+    rev: v0.18.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.16.0
+    rev: v1.17.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -37,17 +37,17 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.7.8
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.19.0
+    rev: v1.23.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.1
+    rev: 1.6.2
     hooks:
       - id: bandit
         args:
@@ -57,7 +57,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.1.0a0
+    rev: v4.1.1a0
     hooks:
       - id: ansible-lint
         # files: molecule/default/playbook.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,7 +1,33 @@
 ---
+# Based on ansible-lint config
 extends: default
 
 rules:
-  # yamllint doesn't like when we use yes and no for true and false,
-  # but that's pretty standard in Ansible.
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
   truthy: disable

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ None.
 
 ## Role Variables ##
 
-None.
+The variable `days_before_inactive` determines the number of days a
+user can go without logging in before his or her account is determined
+to be inactive and is disabled.  If not set, this variable takes on
+the default value of 45 days.
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+days_before_inactive: 45

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: First Last
   description: Skeleton Ansible role
-  company: CISA NCATS
+  company: CISA Cyber Assessments
   license: CC0
   min_ansible_version: 2.0
   platforms:

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,9 +6,17 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
-    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -5,12 +5,18 @@ Docker driver installation guide
 Requirements
 ============
 
-* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
 * Docker Engine
-* docker-py
-* docker
 
 Install
 =======
 
-    $ sudo pip install docker-py
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,6 +10,10 @@ platforms:
     image: debian:stretch-slim
   - name: debian10
     image: debian:buster-slim
+  - name: fedora29
+    image: fedora:29
+  - name: fedora30
+    image: fedora:30
   - name: amazon2018.03
     image: amazonlinux:2018.03
 provisioner:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,17 @@
+---
+# We want to copy a cron job to /etc/cron.daily, so that directory
+# needs to exist.  One way to make sure that it does is to go ahead
+# and install cron.  On Fedora, the cron package name is cronie.
+- name: Group hosts by OS distribution
+  hosts: all
+  tasks:
+    - name: Group hosts by OS distribution
+      group_by:
+        key: os_{{ ansible_facts['distribution'] }}
+- name: Install cronie (Fedora)
+  hosts: os_Fedora
+  tasks:
+    - name: Install cronie (Fedora)
+      package:
+        name:
+          - cronie

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,11 +16,14 @@ def test_packages(host, pkg):
     assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize("f", ["/etc/cron.daily/disable_inactive_users.sh"])
-def test_files(host, f):
+@pytest.mark.parametrize(
+    "f,content", [("/etc/cron.daily/disable_inactive_users.sh", "-45 days")]
+)
+def test_files(host, f, content):
     """Test that the appropriate files were installed."""
     assert host.file(f).exists
     assert host.file(f).is_file
     assert host.file(f).user == "root"
     assert host.file(f).group == "root"
     assert host.file(f).mode == 0o500
+    assert host.file(f).contains(content)

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -14,3 +14,13 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_packages(host, pkg):
     """Test that the appropriate packages were installed."""
     assert host.package(pkg).is_installed
+
+
+@pytest.mark.parametrize("f", ["/etc/cron.daily/disable_inactive_users.sh"])
+def test_files(host, f):
+    """Test that the appropriate files were installed."""
+    assert host.file(f).exists
+    assert host.file(f).is_file
+    assert host.file(f).user == "root"
+    assert host.file(f).group == "root"
+    assert host.file(f).mode == 0o500

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
-- name: Install FreeIPA server
-  package:
-    name:
-      - freeipa-server
-    state: present
+- name: Install FreeIPA server and a cron job to disable inactive users
+  block:
+    - name: Install FreeIPA server
+      package:
+        name:
+          - freeipa-server
+        state: present
+    - name: Install a daily cron job to disable inactive users
+      template:
+        src: disable_inactive_users.j2.sh
+        dest: /etc/cron.daily/disable_inactive_users.sh
+        mode: 0500
+  tags:
+    - freeipa-server

--- a/templates/disable_inactive_users.j2.sh
+++ b/templates/disable_inactive_users.j2.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+###
+# We're running as root, so login to kerberos using the host's keytab
+#
+# It would be better to create a kerberos service instead, but
+# that is left as a future improvement.
+###
+kinit -k -t /etc/krb5.keytab
+
+###
+# Extract the domain from the host keytab
+#
+# This is some potent sed fu.  Match the first line containing
+# "host/something1@something2", then convert something2 to lower case
+# and print it, and finally quit sed.
+###
+domain=$(klist -k /etc/krb5.keytab \
+             | sed --quiet "/.*host\/\(.*\)@\(.*\)/{s//\L\2/p;q}")
+
+###
+# Convert the domain into an LDAP searchbase
+###
+searchbase="cn=users,cn=accounts"
+# The "domain" item below that looks like shell variable is actually
+# replaced by the Terraform templating engine.  Hence we can ignore
+# the "undefined variable" warnings from shellcheck.
+#
+# shellcheck disable=SC2154
+g="${domain}"
+# While g still contains a dot character...
+while grep --quiet --fixed-strings "." <<< "$g"
+do
+    # Extract the longest non-dot-containing string from the beginning
+    # of $g
+    tmp=$(expr "$g" : '\([^\.]*\)')
+    # Append $tmp onto the end of $searchbase
+    searchbase=$searchbase,dc=$tmp
+    # Remove $tmp and its trailing period from $g.  We use {% raw %}
+    # here to tell Jinja that there are no templates in this line,
+    # since otherwise it is confused by the braces and special
+    # characters.
+    # {% raw %}
+    g=${g:${#tmp} + 1}
+    # {% endraw %}
+done
+# There are no more dots in $g, so we just have to append the last bit
+# of $g onto $searchbase
+searchbase=$searchbase,dc=$g
+
+###
+# Determine the date corresponding to days_to_become_inactive days
+# ago, in a format that ldapsearch likes
+###
+distant_past=$(date \
+                   --date="$(date) -{{ days_before_inactive | default(45) }} days" \
+                   +%Y%m%d%H%M%SZ)
+
+###
+# Query LDAP to determine all users that are inactive
+###
+users_to_disable=$(ldapsearch \
+                       -b "$searchbase" \
+                       "(krbLastSuccessfulAuth<=$distant_past)" \
+                       uid \
+                       2>/dev/null \
+                       | sed --quiet "/^uid: \(.*\)/{s//\1/p}")
+
+###
+# Disable the users
+###
+for user in $users_to_disable
+do
+    # The ipa user-disable command may fail if the user is already
+    # disabled, for example, but that's not really an error condition
+    # for us.  If it fails for any other reason, the reason should be
+    # discernible from the cron logs.
+    #
+    # In any event, it makes sense to disable errexit for the ipa
+    # user-disable command since, even if the disabling of a
+    # particular user fails, we want the script to proceed with
+    # attempting to disable any other inactive users.
+    set +o errexit
+    ipa user-disable "$user"
+    set -o errexit
+done
+
+###
+# Discard the kerberos credentials
+###
+kdestroy

--- a/templates/disable_inactive_users.j2.sh
+++ b/templates/disable_inactive_users.j2.sh
@@ -64,7 +64,7 @@ searchbase=$searchbase,dc=$g
 # ago, in a format that ldapsearch likes
 ###
 distant_past=$(date \
-                   --date="$(date) -{{ days_before_inactive | default(45) }} days" \
+                   --date="$(date) -{{ days_before_inactive }} days" \
                    +%Y%m%d%H%M%SZ)
 
 ###

--- a/templates/disable_inactive_users.j2.sh
+++ b/templates/disable_inactive_users.j2.sh
@@ -5,6 +5,13 @@ set -o errexit
 set -o pipefail
 
 ###
+# Let's use a temporary kerberos cred cache file so we don't clobber
+# anyone else's
+###
+KRB5CCNAME=$(mktemp)
+export KRB5CCNAME
+
+###
 # We're running as root, so login to kerberos using the host's keytab
 #
 # It would be better to create a kerberos service instead, but


### PR DESCRIPTION
This is a replacement for cisagov/freeipa-master-tf-module#12.  I think this is a better way, and I will cancel cisagov/freeipa-master-tf-module#12 without merging if this PR is approved.

Thanks to @felddy for pointing out that the domain can be retrieved at run time, which was the key to being able to deploy this cron job via Ansible instead of Terraform.