### PR TITLE
Add certs and scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @jsf9k @mcdonnnj @cisagov/team-ois
+*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+*       @dav3r @jsf9k

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-ansible-role.git

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-generic.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 ---
 name: build
 
-on: [
-  push,
-  pull_request
-]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [apb]
 
 env:
   PIP_CACHE_DIR: ~/.cache/pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.21.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.1
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.0
+    rev: v2.4.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -63,31 +63,44 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.21.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.1
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.0
+    rev: v2.4.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,31 +61,44 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,9 @@ repos:
       # https://github.com/hashicorp/terraform/pull/24896
       # is a proprosed fix to deal with `terraform validate` with proxy
       # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
       # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.0a2
+    rev: 3.8.1
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,10 +64,10 @@ repos:
     rev: v2.1.1
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
+  - repo: https://github.com/timothycrosley/isort
     # pick the isort version you'd like to use from
     # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.21.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.0a2
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.0
+    rev: v2.4.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -71,12 +71,12 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -85,7 +85,7 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,19 @@ repos:
     rev: v1.30.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,8 +65,6 @@ repos:
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/timothycrosley/isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
     rev: 4.3.21
     hooks:
       - id: isort

--- a/files/setup_freeipa_replica.sh
+++ b/files/setup_freeipa_replica.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# The admin password for the IPA server's Kerberos admin role
+admin_pw=password
+# The domain for the IPA server (e.g. example.com)
+domain=example.com
+# The hostname of this IPA server (e.g. ipa.example.com)
+hostname=ipa1.$domain
+# The hostname of the IPA server to which to replicate (e.g. ipa0.example.com)
+master_hostname=ipa0.$domain
+
+# Get the default Ethernet interface
+function get_interface {
+    ip route | grep default | sed "s/^.* dev \([^ ]*\).*$/\1/"
+}
+
+# Get the IP address corresponding to an interface
+function get_ip {
+    ip --family inet address show dev "$1" | \
+        grep inet | \
+        sed "s/^ *//" | \
+        cut --delimiter=' ' --fields=2 | \
+        cut --delimiter='/' --fields=1
+}
+
+# Get the PTR record corresponding to an IP
+function get_ptr {
+    dig +noall +ans -x "$1" | sed "s/.*PTR[[:space:]]*\(.*\)/\1/"
+}
+
+interface=$(get_interface)
+ip_address=$(get_ip "$interface")
+
+# Wait until the IP address has a non-Amazon PTR record before
+# proceeding
+ptr=$(get_ptr "$ip_address")
+while grep amazon <<< "$ptr"
+do
+    sleep 30
+    ptr=$(get_ptr "$ip_address")
+done
+
+# Wait until the master is up and running before installing.
+until ipa-replica-conncheck --replica="$master_hostname"
+do
+    sleep 60
+done
+
+# Install the replica
+ipa-replica-install --admin-password="$admin_pw" \
+                    --hostname="$hostname" \
+                    --ip-address="$ip_address" \
+                    --no-ntp \
+                    --unattended
+
+# Add the DHS CA to the pkinit anchors
+sed -i \
+    "/pkinit_anchors = FILE:\/var\/kerberos\/krb5kdc\/cacert\.pem/a \ \ pkinit_anchors = /usr/local/share/dhsca_fullpath.pem" \
+    /var/kerberos/krb5kdc/kdc.conf
+systemctl restart krb5kdc.service
+
+# Trust the self-signed FreeIPA CA
+echo "$admin_pw" | kinit admin
+ipa-certupdate
+kdestroy

--- a/files/setup_freeipa_server.sh
+++ b/files/setup_freeipa_server.sh
@@ -53,6 +53,7 @@ ipa-server-install --realm="$realm" \
                    --admin-password="$admin_pw" \
                    --hostname="$hostname" \
                    --ip-address="$ip_address" \
+                   --no-ntp \
                    --no_hbac_allow \
                    --unattended
 

--- a/files/setup_freeipa_server.sh
+++ b/files/setup_freeipa_server.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# The admin password for the IPA server's Kerberos admin role
+admin_pw=password
+# The password for the IPA server's directory service
+directory_service_pw=password
+# The domain for the IPA server (e.g. example.com)
+domain=example.com
+# The hostname of the IPA server (e.g. ipa.example.com)
+hostname=ipa.$domain
+# Realm for the IPA server (e.g. EXAMPLE.COM)
+realm=${domain^^}
+
+# Get the default Ethernet interface
+function get_interface {
+    ip route | grep default | sed "s/^.* dev \([^ ]*\).*$/\1/"
+}
+
+# Get the IP address corresponding to an interface
+function get_ip {
+    ip --family inet address show dev "$1" | \
+        grep inet | \
+        sed "s/^ *//" | \
+        cut --delimiter=' ' --fields=2 | \
+        cut --delimiter='/' --fields=1
+}
+
+# Get the PTR record corresponding to an IP
+function get_ptr {
+    dig +noall +ans -x "$1" | sed "s/.*PTR[[:space:]]*\(.*\)/\1/"
+}
+
+interface=$(get_interface)
+ip_address=$(get_ip "$interface")
+
+# Wait until the IP address has a non-Amazon PTR record before
+# proceeding
+ptr=$(get_ptr "$ip_address")
+while grep amazon <<< "$ptr"
+do
+    sleep 30
+    ptr=$(get_ptr "$ip_address")
+done
+
+# Install the server
+ipa-server-install --realm="$realm" \
+                   --domain="$domain" \
+                   --ds-password="$directory_service_pw" \
+                   --admin-password="$admin_pw" \
+                   --hostname="$hostname" \
+                   --ip-address="$ip_address" \
+                   --no_hbac_allow \
+                   --unattended
+
+# Add the DHS CA to the pkinit anchors
+sed -i \
+    "/pkinit_anchors = FILE:\/var\/kerberos\/krb5kdc\/cacert\.pem/a \ \ pkinit_anchors = /usr/local/share/dhsca_fullpath.pem" \
+    /var/kerberos/krb5kdc/kdc.conf
+systemctl restart krb5kdc.service
+
+echo "$admin_pw" | kinit admin
+# Trust the self-signed FreeIPA CA
+ipa-certupdate
+# Create the dhs_certmapdata rule
+ipa certmaprule-add dhs_certmapdata --matchrule '<ISSUER>O=U.S. Government'
+kdestroy

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,12 +19,9 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 29
-        # Ansible currently insists on installing python2-dnf, which
-        # does not exist in Fedora 30.  Until that is resolved, we
-        # can't use Fedora 30.
-        # - 30
         - 31
+        - 32
+        - 33
     - name: Ubuntu
       versions:
         - bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,12 +19,8 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 29
-        # Ansible currently insists on installing python2-dnf, which
-        # does not exist in Fedora 30.  Until that is resolved, we
-        # can't use Fedora 30.
-        # - 30
-        - 31
+        - 32
+        - 33
     - name: Ubuntu
       versions:
         - bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 31
         - 32
         - 33
     - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,12 +8,8 @@ galaxy_info:
   platforms:
     - name: Fedora
       versions:
-        - 29
-        # Ansible currently insists on installing python2-dnf, which
-        # does not exist in Fedora 30.  Until that is resolved, we
-        # can't use Fedora 30.
-        # - 30
-        - 31
+        - 32
+        - 33
   galaxy_tags:
     - freeipa
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,15 +20,12 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora29
-    image: fedora:29
-  # Ansible currently insists on installing python2-dnf, which does
-  # not exist in Fedora 30.  Until that is resolved, we can't use
-  # Fedora 30.
-  # - name: fedora30
-  #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: fedora32
+    image: fedora:32
+  - name: fedora33
+    image: fedora:33
   - name: ubuntu16
     image: ubuntu:xenial
   - name: ubuntu18

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,8 +20,6 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora31
-    image: fedora:31
   - name: fedora32
     image: fedora:32
   - name: fedora33

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,15 +20,10 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora29
-    image: fedora:29
-  # Ansible currently insists on installing python2-dnf, which does
-  # not exist in Fedora 30.  Until that is resolved, we can't use
-  # Fedora 30.
-  # - name: fedora30
-  #   image: fedora:30
-  - name: fedora31
-    image: fedora:31
+  - name: fedora32
+    image: fedora:32
+  - name: fedora33
+    image: fedora:33
   - name: ubuntu16
     image: ubuntu:xenial
   - name: ubuntu18

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,15 +9,10 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: fedora29
-    image: fedora:29
-  # Ansible currently insists on installing python2-dnf, which does
-  # not exist in Fedora 30.  Until that is resolved, we can't use
-  # Fedora 30.
-  # - name: fedora30
-  #   image: fedora:30
-  - name: fedora31
-    image: fedora:31
+  - name: fedora32
+    image: fedora:32
+  - name: fedora33
+    image: fedora:33
 provisioner:
   name: ansible
   config_options:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,13 +19,18 @@ def test_packages(host, pkg):
 
 
 @pytest.mark.parametrize(
-    "f,content", [("/etc/cron.daily/disable_inactive_users.sh", "-45 days")]
+    "f",
+    [
+        "/etc/cron.daily/disable_inactive_users.sh",
+        "/usr/local/share/dhsca_fullpath.p7b",
+        "/usr/local/share/dhsca_fullpath.pem",
+        "/usr/local/bin/setup_freeipa_replica.sh",
+        "/usr/local/bin/setup_freeipa_server.sh",
+    ],
 )
-def test_files(host, f, content):
+def test_files(host, f):
     """Test that the appropriate files were installed."""
     assert host.file(f).exists
     assert host.file(f).is_file
     assert host.file(f).user == "root"
     assert host.file(f).group == "root"
-    assert host.file(f).mode == 0o500
-    assert host.file(f).contains(content)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,34 @@
 ---
-- name: Install FreeIPA server and a cron job to disable inactive users
-  block:
-    - name: Install FreeIPA server
-      package:
-        name:
-          - freeipa-server
-        state: present
-    - name: Install a daily cron job to disable inactive users
-      template:
-        src: disable_inactive_users.j2.sh
-        dest: /etc/cron.daily/disable_inactive_users.sh
-        mode: 0500
-  tags:
-    - freeipa-server
+- name: Install FreeIPA server
+  package:
+    name:
+      - freeipa-server
+    state: present
+
+- name: Install a daily cron job to disable inactive users
+  template:
+    src: disable_inactive_users.j2.sh
+    dest: /etc/cron.daily/disable_inactive_users.sh
+    mode: 0500
+
+- name: Copy DHS CA certs
+  get_url:
+    dest: /usr/local/share
+    url: https://pki.treas.gov/dhsca_fullpath.p7b
+- name: Convert P7B to PEM
+  command:
+    cmd: >
+      openssl pkcs7 -print_certs
+      -in /usr/local/share/dhsca_fullpath.p7b
+      -inform DER
+      -out /usr/local/share/dhsca_fullpath.pem
+    creates: /usr/local/share/dhsca_fullpath.pem
+
+- name: Copy server and replica setup scripts
+  copy:
+    src: "{{ item }}"
+    dest: /usr/local/bin
+    mode: 0700
+  loop:
+    - setup_freeipa_replica.sh
+    - setup_freeipa_server.sh


### PR DESCRIPTION
## 🗣 Description

This pull request adds the DHS CA certs and scripts for setting up a server or replica.

## 💭 Motivation and Context

The DHS CA certs are required in order for users to be able to `kinit` using only their PIVs.

The scripts are necessary because I am changing the IPA servers/replicas to no longer set themselves up via cloud-init.  I am doing this to remove the distinction between servers and replicas and therefore make the problem of updating/redeploying IPA servers more tractable.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
