### PR TITLE
Add missing permission to User Administrator role

### DIFF
--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -110,6 +110,15 @@ function setup {
                 --maprule '(userCertificate;binary={cert})' \
                 --desc 'For PIV certificates WITH parentheses in the CN.  Zero is highest priority according to man sss-certmap.' \
                 --priority 0
+
+            # We make use of user certmap data in order to match
+            # certificates with FreeIPA users.  It follows that folks
+            # who are in the user administrator role need permission
+            # to manage users' certmap data.  This permission is
+            # lacking from that role by default, but this command
+            # remedies that.
+            ipa privilege-add-permission "User Administrators" \
+                --permissions="System: Manage User Certificate Mappings"
             ;;
         replica)
             # Install the replica

--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -70,6 +70,7 @@ function setup {
                                --no_hbac_allow \
                                --mkhomedir
 
+            kinit admin
             # Get kerberos credentials and create the dhs_certmapdata
             # rules.  These rules are necessary in order to associate
             # a certificate with a user during PKINIT.
@@ -100,7 +101,6 @@ function setup {
             # For more details about FreeIPA, certmap rules, and
             # certmap data, see here:
             # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_identity_management/conf-certmap-idm_configuring-and-managing-idm
-            kinit admin
             ipa certmaprule-add dhs_certmapdata \
                 --matchrule '<ISSUER>O=U\.S\. Government' \
                 --maprule '(ipacertmapdata=X509:<I>{issuer_dn!nss_x500}<S>{subject_dn!nss_x500})' \


### PR DESCRIPTION
## 🗣 Description

This pull request adds the "System: Manage User Certificate Mappings" permission to the "User Administrators" privilege, which is in turn attached to the "User Administrator" FreeIPA role.

## 💭 Motivation and Context

@mzack5020 noticed that he was unable to add certmap data to some users he was creating, and this turned out to be the cause.  This change will fix the issue from the get go for future deployments. 

## 🧪 Testing

The command I added is the same command I ran on `ipa0` in our staging environment, which fixed @mzack5020's issue.  I have also applied this change to our production environment.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
