### PR TITLE
Enable authselect features clobbered by FreeIPA install scripts

### DIFF
--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -155,6 +155,12 @@ function setup {
     ipa host-add-principal \
         "$hostname" \
         host/"$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)"."$domain"
+
+    # Enable features in the active authselect profile so that all necessary
+    # hardened rules will be activated.
+    authselect enable-feature with-faillock
+    authselect enable-feature with-fingerprint
+    authselect enable-feature with-smartcard
 }
 
 

--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -157,9 +157,12 @@ function setup {
         host/"$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)"."$domain"
 
     # Enable features in the active authselect profile so that all necessary
-    # hardened rules will be activated.  Note that these features are enabled
-    # in ansible-role-hardening, however ipa-server-install and
-    # ipa-client-install clobber them, so we must re-enable them here.
+    # hardened rules will be activated.
+    # Notes:
+    #  - These features are enabled in ansible-role-hardening, however
+    #    ipa-server-install and ipa-client-install clobber them, so we must
+    #    re-enable them here.
+    #  - These authselect commands are RedHat-only (but so are FreeIPA servers).
     authselect enable-feature with-faillock
     authselect enable-feature with-fingerprint
     authselect enable-feature with-smartcard

--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -157,7 +157,9 @@ function setup {
         host/"$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)"."$domain"
 
     # Enable features in the active authselect profile so that all necessary
-    # hardened rules will be activated.
+    # hardened rules will be activated.  Note that these features are enabled
+    # in ansible-role-hardening, however ipa-server-install and
+    # ipa-client-install clobber them, so we must re-enable them here.
     authselect enable-feature with-faillock
     authselect enable-feature with-fingerprint
     authselect enable-feature with-smartcard


### PR DESCRIPTION


# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR enables several features in the active `authselect` profile so that all necessary hardened rules will be activated.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This will help our AMI be more secure as well as pass several audits in a compliance scan.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All automated tests pass.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
