### PR TITLE
Allow IPA certmaprule to match certificates issued by Entrust

### DIFF
--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -106,9 +106,9 @@ function setup {
                 --maprule '(ipacertmapdata=X509:<I>{issuer_dn!nss_x500}<S>{subject_dn!nss_x500})' \
                 --desc 'For PIV certificates WITHOUT parentheses in the CN. No priority means lowest priority according to man sss-certmap.'
             ipa certmaprule-add dhs_certmapdata_parens \
-                --matchrule '<ISSUER>O=U\.S\. Government<SUBJECT>CN=.*[\(\)].*' \
+                --matchrule '<ISSUER>O=(U\.S\. Government|Entrust)<SUBJECT>CN=.*[\(\)].*' \
                 --maprule '(userCertificate;binary={cert})' \
-                --desc 'For PIV certificates WITH parentheses in the CN.  Zero is highest priority according to man sss-certmap.' \
+                --desc 'For PIV certificates WITH parentheses in the CN.  Entrust issuer covers DOE certificates used by INL contractors.  Zero is highest priority according to man sss-certmap.' \
                 --priority 0
 
             # We make use of user certmap data in order to match

--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -96,7 +96,8 @@ function setup {
             # Once the sssd pull request mentioned above is approved,
             # merged, and appears in a release, we should be able to
             # use a single certmap rule for all users that leverages
-            # the user certmap data.
+            # the user certmap data.  This has been documented in:
+            # https://github.com/cisagov/ansible-role-freeipa-server/issues/31
             #
             # For more details about FreeIPA, certmap rules, and
             # certmap data, see here:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR modifies the `dhs_certmapdata_parens` certificate matching rule so that it matches certificates issued by Entrust (in addition to the U.S. Government).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Our INL contractors require access to the COOL, but their DOE PIV certificates are issued by Entrust, so that is why we are updating this rule.  There is no need to update the other rule because it only applies to PIV users whose CNs do not include parentheses (namely Federal employees) and we only have need at this time to support contractors with Entrust-issued certificates.

Note that this PR is closely related to https://github.com/cisagov/ansible-role-openvpn/pull/39.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Here's how this change was tested:

1. I made sure that the user with the Entrust-issued PIV certificate was added to our Staging FreeIPA database.
1. I used the FreeIPA "Certificate Mapping Match" page to confirm that the Entrust-issued certificate did not match any users in our IPA database.
1. I manually made the regex change to the `dhs_certmapdata_parens` rule (via the Staging FreeIPA web GUI) to match Entrust-issued certificates.
1. I restarted the sssd service (`sudo systemctl restart sssd`) on all active Staging FreeIPA instances to force the certmap rules to be reloaded.
1. I used the FreeIPA "Certificate Mapping Match" page to confirm that the Entrust-issued PIV certificate was now matching the correct user in our IPA database.

Also, while I was looking at this, I did some additional testing to see if we still needed two separate certmap rules, now that we are using a version of FreeIPA that includes https://github.com/SSSD/sssd/pull/1036.  Unfortunately, I was still unable to figure out why a user with parentheses in their CN wasn't matching with just [a single rule (`dhs_certmapdata`)](https://github.com/cisagov/ansible-role-freeipa-server/blob/develop/files/00_setup_freeipa.sh#L104-L107) enabled.  This bears further investigation- I created #31 to document this issue, which was already [well-documented in the code](https://github.com/cisagov/ansible-role-freeipa-server/blob/develop/files/00_setup_freeipa.sh#L78-L103).

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
