### PR TITLE
Use IMDSv2 when retrieving the instance ID

### DIFF
--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -151,11 +151,18 @@ function setup {
     /var/kerberos/krb5kdc/kdc.conf
   systemctl restart krb5kdc.service
 
+  # Grab the instance ID from the AWS Instance Meta-Data Service
+  # (IMDSv2)
+  imds_token=$(curl --silent \
+      --request PUT \
+      --header "X-aws-ec2-metadata-token-ttl-seconds: 10" \
+    http://169.254.169.254/latest/api/token)
+  instance_id=$(curl --silent \
+      --header "X-aws-ec2-metadata-token: $imds_token" \
+    http://169.254.169.254/latest/meta-data/instance-id)
   # Add a principal alias for the instance ID so folks can ssh in
   # via SSM Session Manager.
-  ipa host-add-principal \
-    "$hostname" \
-    host/"$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)"."$domain"
+  ipa host-add-principal "$hostname" host/"$instance_id"."$domain"
 
   # Enable features in the active authselect profile so that all necessary
   # hardened rules will be activated.

--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -160,9 +160,16 @@ function setup {
   instance_id=$(curl --silent \
       --header "X-aws-ec2-metadata-token: $imds_token" \
     http://169.254.169.254/latest/meta-data/instance-id)
-  # Add a principal alias for the instance ID so folks can ssh in
-  # via SSM Session Manager.
-  ipa host-add-principal "$hostname" host/"$instance_id"."$domain"
+  # Verify that the instance ID is valid
+  if [[ $instance_id =~ ^i-[0-9a-f]{17}$ ]]
+  then
+    # Add a principal alias for the instance ID so folks can ssh in
+    # via SSM Session Manager.
+    ipa host-add-principal "$hostname" host/"$instance_id"."$domain"
+  else
+    echo Invalid AWS instance ID "$instance_id" - not attempting to \
+      create principal alias for instance ID
+  fi
 
   # Enable features in the active authselect profile so that all necessary
   # hardened rules will be activated.


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `00_setup_freeipa.sh` script to use IMDSv2 when retrieving the instance ID from the AWS meta-data service.

## 💭 Motivation and context ##

We want to enforce IMDSv2-only on our instances to satisfy cisagov/cool-system#174 and cisagov/cool-system#175, and this change will help us with that.

## 🧪 Testing ##

* All `pre-commit` hooks and `molecule` tests pass
* I verified that the new code will work on a running instance in our COOL staging environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
