### PR TITLE
Add the NETBIOS name to the FreeIPA install commands

### DIFF
--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -10,6 +10,11 @@ set -o pipefail
 #
 # hostname: The hostname of this IPA server (e.g. ipa1.example.com).
 #
+# netbios_name: The NETBIOS name to be used by this IPA server
+# (e.g. EXAMPLE).  Note that NETBIOS names are restricted to at most
+# 15 characters.  These characters must consist only of uppercase
+# letters, numbers, and dashes.
+#
 # realm: The realm for the IPA server (e.g. EXAMPLE.COM).
 #
 #
@@ -18,6 +23,11 @@ set -o pipefail
 # domain: The domain for the IPA server (e.g. example.com).
 #
 # hostname: The hostname of this IPA server (e.g. ipa1.example.com).
+#
+# netbios_name: The NETBIOS name to be used by this IPA server
+# (e.g. EXAMPLE).  Note that NETBIOS names are restricted to at most
+# 15 characters.  These characters must consist only of uppercase
+# letters, numbers, and dashes.
 
 # Load above variables from a file installed by cloud-init:
 freeipa_vars_file=/var/lib/cloud/instance/freeipa-vars.sh
@@ -66,6 +76,7 @@ function setup {
         --domain="$domain" \
         --hostname="$hostname" \
         --ip-address="$ip_address" \
+        --netbios-name="$netbios_name" \
         --no-ntp \
         --no_hbac_allow \
         --mkhomedir
@@ -136,7 +147,9 @@ function setup {
       ipa-client-install --hostname="$hostname" \
         --mkhomedir \
         --no-ntp
-      ipa-replica-install --setup-ca \
+      ipa-replica-install \
+        --netbios-name="$netbios_name" \
+        --setup-ca \
         --setup-kra
       ;;
     *)


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the FreeIPA server install script to specify the NETBIOS name when running the replica and server install commands.

## 💭 Motivation and context ##

This option is now required, even though it isn't actually used in our case.

See also:
- cisagov/freeipa-server-tf-module#59
- cisagov/cool-sharedservices-freeipa#46

## 🧪 Testing ##

Automated testing passes.  I also build a staging AMI with these changes and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.