### PR TITLE
Also install freeipa-healthcheck

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,7 +12,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["freeipa-server"])
+@pytest.mark.parametrize("pkg", ["freeipa-healthcheck", "freeipa-server"])
 def test_packages(host, pkg):
     """Test that the appropriate packages were installed."""
     assert host.package(pkg).is_installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install FreeIPA server
   ansible.builtin.package:
     name:
+      - freeipa-healthcheck
       - freeipa-server
     state: present
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the `freeipa-healthcheck` package to our FreeIPA server installations.

## 💭 Motivation and context ##

This package provides `ipa-healthcheck`, which can be used to get a list of errors and warnings about the health of FreeIPA servers.  It is a useful tool to have around.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.