### PR TITLE
Support some Apache configuration tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,8 @@ jobs:
       matrix:
         scenario:
           - default
+          - disable_trace
+          - enable_hsts
     steps:
       - id: harden-runner
         name: Harden the runner

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,7 +111,7 @@ repos:
     hooks:
       - id: bandit
         # Bandit complains about the use of assert() in tests
-        exclude: molecule/(default|systemd_enabled)/tests
+        exclude: molecule/(default|disable_trace|enable_hsts)/tests
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black-pre-commit-mirror

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ None.
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | freeipa_days_before_inactive | The number of days a user can go without logging in before his or her account is determined to be inactive and is disabled. | `45` | No |
+| freeipa_disable_trace | Whether or not to disable trace functionality for all HTTP and HTTPS requests. | `false` | No |
+| freeipa_enable_hsts | Whether or not to return HSTS headers for all HTTP and HTTPS requests. | `false` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,12 @@
 ---
+# The number of days a user can go without logging in before his or
+# her account is determined to be inactive and is disabled.
 freeipa_days_before_inactive: 45
+
+# Whether or not to disable trace functionality for all HTTP and HTTPS
+# requests.
+freeipa_disable_trace: false
+
+# Whether or not to return HSTS headers for all HTTP and HTTPS
+# requests.
+freeipa_enable_hsts: false

--- a/files/disable_trace.conf
+++ b/files/disable_trace.conf
@@ -1,0 +1,1 @@
+TraceEnable off

--- a/files/enable_hsts.conf
+++ b/files/enable_hsts.conf
@@ -1,0 +1,1 @@
+Header always set Strict-Transport-Security "max-age=31536000; includeSubdomains; preload"

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -10,51 +10,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: geerlingguy/docker-amazonlinux2023-ansible:latest
-    name: amazonlinux2023-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: geerlingguy/docker-debian11-ansible:latest
-    name: debian11-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: cisagov/docker-debian12-ansible:latest
-    name: debian12-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: cisagov/docker-kali-ansible:latest
-    name: kali-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # FreeIPA server is only available for the RedHat, Fedora, and
+  # CentOS Linux distributions.  Among these distributions we only
+  # support Fedora.
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora37-ansible:latest
@@ -68,24 +26,6 @@ platforms:
     command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora38-ansible:latest
     name: fedora38-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: geerlingguy/docker-ubuntu2204-ansible:latest
-    name: ubuntu-22-systemd
     platform: amd64
     pre_build_image: true
     privileged: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,1 +1,1 @@
-molecule-no-systemd.yml
+molecule-with-systemd.yml

--- a/molecule/disable_trace/INSTALL.rst
+++ b/molecule/disable_trace/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/disable_trace/converge.yml
+++ b/molecule/disable_trace/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include ansible-role-freeipa-server
+      ansible.builtin.include_role:
+        name: ansible-role-freeipa-server
+      vars:
+        freeipa_disable_trace: true

--- a/molecule/disable_trace/molecule-no-systemd.yml
+++ b/molecule/disable_trace/molecule-no-systemd.yml
@@ -1,0 +1,1 @@
+../default/molecule-no-systemd.yml

--- a/molecule/disable_trace/molecule-with-systemd.yml
+++ b/molecule/disable_trace/molecule-with-systemd.yml
@@ -1,0 +1,1 @@
+../default/molecule-with-systemd.yml

--- a/molecule/disable_trace/molecule.yml
+++ b/molecule/disable_trace/molecule.yml
@@ -1,0 +1,37 @@
+---
+# This molecule configuration file is suitable for testing Ansible
+# roles that _do_ require SystemD.  If your Ansible role _does not_
+# require SystemD then you should use molecule-no-systemd.yml instead.
+#
+# Note that the molecule configuration file that is symlinked to
+# molecule.yml is the one that will be used.
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  # FreeIPA server is only available for the RedHat, Fedora, and
+  # CentOS Linux distributions.  Among these distributions we only
+  # support Fedora.
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-fedora37-ansible:latest
+    name: fedora37-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-fedora38-ansible:latest
+    name: fedora38-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+scenario:
+  name: disable_trace
+verifier:
+  name: testinfra

--- a/molecule/disable_trace/prepare.yml
+++ b/molecule/disable_trace/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/disable_trace/requirements.yml
+++ b/molecule/disable_trace/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/disable_trace/tests/test_default.py
+++ b/molecule/disable_trace/tests/test_default.py
@@ -1,0 +1,1 @@
+../../default/tests/test_default.py

--- a/molecule/disable_trace/tests/test_disable_trace.py
+++ b/molecule/disable_trace/tests/test_disable_trace.py
@@ -1,0 +1,46 @@
+"""Module containing the tests for the disable_trace scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+@pytest.mark.parametrize(
+    "f",
+    [
+        "/etc/httpd/conf.d/disable_trace.conf",
+    ],
+)
+def test_apache_config_files(host, f):
+    """Verify the appropriate Apache config files were installed."""
+    assert host.file(f).exists
+    assert host.file(f).is_file
+    assert host.file(f).user == "root"
+    assert host.file(f).group == "root"
+
+
+def test_apache_config(host):
+    """Verify Apache can parse the config with the additions we made."""
+    # The ssl.conf file is invalid until FreeIPA's self-signed
+    # certificate is present.  This can only be true after
+    # ipa-server-install has been run, so we need to temporarily move
+    # this file out of the way.  This does not affect the results of
+    # the test, since we are not touching ssl.conf anyway.
+    cmd = host.run("mv /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.conf.xxx")
+    assert cmd.rc == 0
+
+    # Now verify that Apache is OK with the configuration _with_ the
+    # modification(s) we have made.
+    cmd = host.run("apachectl configtest")
+    assert cmd.rc == 0
+
+    # Put back the ssl.conf file.
+    cmd = host.run("mv /etc/httpd/conf.d/ssl.conf.xxx /etc/httpd/conf.d/ssl.conf")
+    assert cmd.rc == 0

--- a/molecule/disable_trace/upgrade.yml
+++ b/molecule/disable_trace/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/molecule/enable_hsts/INSTALL.rst
+++ b/molecule/enable_hsts/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/enable_hsts/converge.yml
+++ b/molecule/enable_hsts/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include ansible-role-freeipa-server
+      ansible.builtin.include_role:
+        name: ansible-role-freeipa-server
+      vars:
+        freeipa_enable_hsts: true

--- a/molecule/enable_hsts/molecule-no-systemd.yml
+++ b/molecule/enable_hsts/molecule-no-systemd.yml
@@ -1,0 +1,1 @@
+../default/molecule-no-systemd.yml

--- a/molecule/enable_hsts/molecule-with-systemd.yml
+++ b/molecule/enable_hsts/molecule-with-systemd.yml
@@ -1,0 +1,1 @@
+../default/molecule-with-systemd.yml

--- a/molecule/enable_hsts/molecule.yml
+++ b/molecule/enable_hsts/molecule.yml
@@ -1,0 +1,37 @@
+---
+# This molecule configuration file is suitable for testing Ansible
+# roles that _do_ require SystemD.  If your Ansible role _does not_
+# require SystemD then you should use molecule-no-systemd.yml instead.
+#
+# Note that the molecule configuration file that is symlinked to
+# molecule.yml is the one that will be used.
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  # FreeIPA server is only available for the RedHat, Fedora, and
+  # CentOS Linux distributions.  Among these distributions we only
+  # support Fedora.
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-fedora37-ansible:latest
+    name: fedora37-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-fedora38-ansible:latest
+    name: fedora38-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+scenario:
+  name: enable_hsts
+verifier:
+  name: testinfra

--- a/molecule/enable_hsts/prepare.yml
+++ b/molecule/enable_hsts/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/enable_hsts/requirements.yml
+++ b/molecule/enable_hsts/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/enable_hsts/tests/test_default.py
+++ b/molecule/enable_hsts/tests/test_default.py
@@ -1,0 +1,1 @@
+../../default/tests/test_default.py

--- a/molecule/enable_hsts/tests/test_enable_hsts.py
+++ b/molecule/enable_hsts/tests/test_enable_hsts.py
@@ -1,0 +1,46 @@
+"""Module containing the tests for the enable_hsts scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+@pytest.mark.parametrize(
+    "f",
+    [
+        "/etc/httpd/conf.d/enable_hsts.conf",
+    ],
+)
+def test_apache_config_files(host, f):
+    """Test that the appropriate Apache configuration files were installed."""
+    assert host.file(f).exists
+    assert host.file(f).is_file
+    assert host.file(f).user == "root"
+    assert host.file(f).group == "root"
+
+
+def test_apache_config(host):
+    """Verify Apache can parse the config with the additions we made."""
+    # The ssl.conf file is invalid until FreeIPA's self-signed
+    # certificate is present.  This can only be true after
+    # ipa-server-install has been run, so we need to temporarily move
+    # this file out of the way.  This does not affect the results of
+    # the test, since we are not touching ssl.conf anyway.
+    cmd = host.run("mv /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.conf.xxx")
+    assert cmd.rc == 0
+
+    # Now verify that Apache is OK with the configuration _with_ the
+    # modification(s) we have made.
+    cmd = host.run("apachectl configtest")
+    assert cmd.rc == 0
+
+    # Put back the ssl.conf file.
+    cmd = host.run("mv /etc/httpd/conf.d/ssl.conf.xxx /etc/httpd/conf.d/ssl.conf")
+    assert cmd.rc == 0

--- a/molecule/enable_hsts/upgrade.yml
+++ b/molecule/enable_hsts/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,6 @@
     name:
       - freeipa-healthcheck
       - freeipa-server
-    state: present
 
 - name: Install a daily cron job to disable inactive users
   ansible.builtin.template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,22 @@
       - freeipa-healthcheck
       - freeipa-server
 
+- name: Install Apache config fragment to disable trace functionality
+  ansible.builtin.copy:
+    dest: /etc/httpd/conf.d
+    mode: 0500
+    src: disable_trace.conf
+  when:
+    - freeipa_disable_trace
+
+- name: Install Apache config fragment to enable HSTS functionality
+  ansible.builtin.copy:
+    dest: /etc/httpd/conf.d
+    mode: 0500
+    src: enable_hsts.conf
+  when:
+    - freeipa_enable_hsts
+
 - name: Install a daily cron job to disable inactive users
   ansible.builtin.template:
     dest: /etc/cron.daily/disable_inactive_users.sh

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,9 +7,9 @@
 
 - name: Install a daily cron job to disable inactive users
   ansible.builtin.template:
-    src: disable_inactive_users.j2.sh
     dest: /etc/cron.daily/disable_inactive_users.sh
     mode: 0500
+    src: disable_inactive_users.j2.sh
 
 - name: Copy DHS CA certs
   ansible.builtin.get_url:
@@ -27,6 +27,6 @@
 
 - name: Copy setup script
   ansible.builtin.copy:
-    src: 00_setup_freeipa.sh
     dest: /usr/local/sbin
     mode: 0500
+    src: 00_setup_freeipa.sh


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds two Ansible role variables to support some Apache configuration tweaks:  the disabling of trace functionality and the enabling of HSTS header functionality
- Adds two Molecule scenarios to test the use of these two new Ansible role variables
- Switches to a SystemD-enabled Molecule configuration.  This is necessary because we leverage `apachectl` to check the Apache configuration after we have made our changes.

## 💭 Motivation and context ##

The security folks are concerned that trace functionality is enabled on the Apache server that sits in front of FreeIPA.  This is despite [this note in the Apache documentation](https://httpd.apache.org/docs/2.4/mod/core.html#traceenable).

The security folks are also concerned that the same Apache server is not returning HSTS headers.

See cisagov/cool-system-internal#135 and cisagov/cool-system-internal#136 for more details.

## 🧪 Testing ##

All automated tests pass.  I also built a new FreeIPA AMI for COOL staging that included these changes and verified that it functioned as expected.

## 📷 Screenshots ##

Here you can see on the left that:
- The `Strict-Transport-Security` HTML header is present in the response from the web server.
- The web server returns a 405 code in response to a `TRACE` HTTP method request, indicating that the method is disallowed.
![curl](https://github.com/cisagov/ansible-role-freeipa-server/assets/5521725/15504070-1906-4164-ac6d-84137e00af8d)

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.