### PR TITLE
Do not attempt to disable any users in the `admins` group

### DIFF
--- a/files/disable_inactive_freeipa_users.sh
+++ b/files/disable_inactive_freeipa_users.sh
@@ -59,11 +59,16 @@ else
   # kinit via the host's keytab.
   kinit -k -t /etc/krb5.keytab
 
-  # Grab a list of all non-disabled FreeIPA users
+  # Grab a list of all non-disabled, FreeIPA users who are not in the
+  # admins group.
+  #
+  # We don't want to disable any users in the admins group, nor do the
+  # FreeIPA servers have the permission to do that.
   users=$(
     # Note that we disable the size and time limits normally in place
     # when running ipa user-find.
-    ipa user-find --disabled=false --sizelimit=0 --timelimit=0 \
+    ipa user-find --disabled=false --not-in-groups=admins \
+      --sizelimit=0 --timelimit=0 \
       |
       # --quiet means no printing unless the p command is used
       sed --quiet 's/^\s*User login:\s*//p'


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies teh script to no longer attempt to disable any users in the `admins` group.

## 💭 Motivation and context ##

We don't want to disable any users in the `admins` group, nor do the FreeIPA servers have the permission to do that.

Resolves #78.

## 🧪 Testing ##

All automated tests pass.  I also deployed these changes to our staging and production COOL environments and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.